### PR TITLE
Updated SyncedCron Package Name

### DIFF
--- a/package.js
+++ b/package.js
@@ -14,7 +14,7 @@ Package.onUse(function (api) {
   api.use('ejson', ['client', 'server']);
   api.use('http', ['client', 'server']);
   api.use('mongo', ['client', 'server']);
-  api.use('percolatestudio:synced-cron@1.1.0', 'server');
+  api.use('percolate:synced-cron@1.2.0', 'server');
 
   api.addFiles('src/common/globals.js', ['client', 'server']);
 


### PR DESCRIPTION
The syncedcron package has changed to `percolate:synced-cron` (was percolatestudio:synced-cron).  It's also now updated to 1.2.0.

Without this change, two copies were sometimes getting installed (identified by a `/cronHistory/insert' is already defined` message in the server logs) since meteor couldn't manage the dependency properly and other packages are now using the new `percolate:synced-cron` name.  This should resolve that problem.  I tested with the new 1.2.0 and things seem to be working fine.
